### PR TITLE
migration to the new bullshit-memory.club domain

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "liveServer.settings.port": 5502,
+    "liveServer.settings.host": "local.bullshit-memory.club",
     "git.ignoreLimitWarning": true
 }

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+bullshit-memory.club

--- a/app.html
+++ b/app.html
@@ -27,9 +27,7 @@
     <footer></footer>
 
     <script>
-      const page = `${config.context}app.html`
       const userData = document.querySelector("[data-container=user]");
-
       const loginHandler = function(response) {
         let header = document.createElement('h1')
         header.innerHTML = "Hello User"

--- a/config.js
+++ b/config.js
@@ -1,9 +1,10 @@
 const config = {
     env: "local",
     context: "/",
+    host: "http://local.bullshit-memory.club:5502",
     sessionName: "LOCAL_DEV_SESSION",
     projectId: "65da39e5573f565f617e",
-    endpoint: "https://db.myglobal.ws/v1",
-    redirect: "http://localhost:5502/app.html?status=okay",
+    endpoint: "https://appwrite.bullshit-memory.club/v1",
+    redirect: "http://local.bullshit-memory.club:5502/app.html?status=okay",
     version: "development"
 }

--- a/index.html
+++ b/index.html
@@ -37,12 +37,12 @@
   <body>
     <header></header>
     <main>
-      <a class="button login-button" href="app.html">Login</a>
+      <a class="button login-button" href="app.html">Login<br />with<br />GitHub</a>
     </main>
     <footer></footer>
     <script>
       const value = readCookie(config.sessionName);
-      const page = `${config.context}/app.html`
+      const page = `${config.host}${config.context}app.html`
       if (value.length > 0) {
         const session = JSON.parse(value);
         if(session) {

--- a/js/auth.js
+++ b/js/auth.js
@@ -3,6 +3,7 @@ const { Client, Account, ID } = Appwrite;
 const client = new Client();
 const account = new Account(client);
 client.setEndpoint(config.endpoint).setProject(config.projectId);
+const page = `${config.host}${config.context}app.html`
 
 const PerformLogin = function(config, loginHandler, errorHandler) {
   const value = readCookie(config.sessionName);

--- a/prod/config.js
+++ b/prod/config.js
@@ -1,9 +1,10 @@
 const config = {
     env: "prod",
-    context: "/bullshit-memory/",
+    context: "/",
+    host: "https://bullshit-memory.club",
     sessionName: "PROD_SESSION",
     projectId: "663ccc32dae944310b32",
-    endpoint: "https://db.myglobal.ws/v1",
-    redirect: "https://games-for-hire.github.io/bullshit-memory/app.html?status=okay",
+    endpoint: "https://appwrite.bullshit-memory.club/v1",
+    redirect: "https://bullshit-memory.club/app.html?status=okay",
     version: "--version--"
 }


### PR DESCRIPTION
We can finally use a real domain (`bullshit-memory.club`) for our setup.
The local setup should now also work with Safari.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced custom host configuration for the Live Server extension.
	- Added a custom domain configuration with `bullshit-memory.club`, enhancing project accessibility.
	- Improved dynamic URL generation for routing and resource loading.

- **Bug Fixes**
	- Removed an unused variable which could impact navigation.

- **Documentation**
	- Updated configuration settings for local and production environments, ensuring accurate routing and API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->